### PR TITLE
Throw error if cache directory cannot be created

### DIFF
--- a/src/DependencyInjection/Compiler/AddInterceptorsPass.php
+++ b/src/DependencyInjection/Compiler/AddInterceptorsPass.php
@@ -33,7 +33,10 @@ class AddInterceptorsPass implements CompilerPassInterface
         $cacheDir = $container->getParameterBag()->resolveValue(
             $container->getParameter('fazland.dto-management.proxy_cache_dir')
         );
-        @\mkdir($cacheDir, 0777, true);
+
+        if (! @\mkdir($cacheDir, 0777, true) && ! \is_dir($cacheDir)) {
+            throw new \RuntimeException(sprintf('Directory "%s" was not created', $cacheDir));
+        }
 
         $this->proxyFactory = $container->get('fazland.dto-management.proxy_factory');
         AnnotationRegistry::registerUniqueLoader('class_exists');

--- a/src/DependencyInjection/DtoManagementExtension.php
+++ b/src/DependencyInjection/DtoManagementExtension.php
@@ -30,7 +30,7 @@ class DtoManagementExtension extends Extension
         /** @var Definition[] $locators */
         $locators = [];
         foreach ($this->process($container, $config['namespaces']) as $interface => $definition) {
-            if (\in_array($interface, $config['exclude'])) {
+            if (\in_array($interface, $config['exclude'], true)) {
                 continue;
             }
 

--- a/src/DtoManagementBundle.php
+++ b/src/DtoManagementBundle.php
@@ -28,7 +28,7 @@ final class DtoManagementBundle extends Bundle
         $cacheDir = $this->container->getParameter('kernel.cache_dir');
 
         $classMap = require "$cacheDir/dto-proxies-map.php";
-        \spl_autoload_register(function (string $className) use (&$classMap): bool {
+        \spl_autoload_register(static function (string $className) use (&$classMap): bool {
             if (! isset($classMap[$className])) {
                 return false;
             }

--- a/src/Proxy/ExpressionLanguage.php
+++ b/src/Proxy/ExpressionLanguage.php
@@ -14,9 +14,9 @@ class ExpressionLanguage extends BaseExpressionLanguage
     {
         $this->addFunction(ExpressionFunction::fromPhp('constant'));
 
-        $this->register('is_granted', function ($attributes, $object = 'null') {
+        $this->register('is_granted', static function ($attributes, $object = 'null') {
             return \sprintf('$auth_checker->isGranted(%s, %s)', $attributes, $object);
-        }, function (array $variables, $attributes, $object = null) {
+        }, static function (array $variables, $attributes, $object = null) {
             return $variables['auth_checker']->isGranted($attributes, $object);
         });
     }

--- a/src/Proxy/Generator/AccessInterceptorGenerator.php
+++ b/src/Proxy/Generator/AccessInterceptorGenerator.php
@@ -82,7 +82,7 @@ class AccessInterceptorGenerator implements ProxyGeneratorInterface
 
         $classGenerator->addMethodFromGenerator(new MethodGenerator\MagicSet($originalClass, $valueHolder, $publicProperties, $propertyInterceptors));
         $classGenerator->addMethodFromGenerator(new MethodGenerator\MagicGet($originalClass, $valueHolder, $publicProperties));
-        $classGenerator->addMethodFromGenerator(new MethodGenerator\MagicIsset($originalClass, $valueHolder, $publicProperties));
+        $classGenerator->addMethodFromGenerator(new MethodGenerator\MagicIsset($originalClass, $valueHolder));
         $classGenerator->addMethodFromGenerator(new MethodGenerator\GetSubscribedServices($originalClass, $options['services']));
     }
 

--- a/src/Proxy/Generator/MethodGenerator/Constructor.php
+++ b/src/Proxy/Generator/MethodGenerator/Constructor.php
@@ -35,13 +35,13 @@ class Constructor extends MethodGenerator
             '$this->'.$valueHolder->getName().' = new \stdClass();'."\n"
             .'$this->'.$locator->getName().' = $'.$locator->getName().';'."\n"
             .self::generateUnsetAccessiblePropertiesCode(Properties::fromReflectionClass($originalClass))
-            .self::generateOriginalConstructorCall($originalClass, $valueHolder)
+            .self::generateOriginalConstructorCall($originalClass)
         );
 
         return $constructor;
     }
 
-    private static function generateOriginalConstructorCall(\ReflectionClass $class, PropertyGenerator $valueHolder): string
+    private static function generateOriginalConstructorCall(\ReflectionClass $class): string
     {
         $originalConstructor = self::getConstructor($class);
         if (null === $originalConstructor) {
@@ -55,7 +55,7 @@ class Constructor extends MethodGenerator
             .\implode(
                 ', ',
                 \array_map(
-                    function (ParameterGenerator $parameter): string {
+                    static function (ParameterGenerator $parameter): string {
                         return ($parameter->getVariadic() ? '...' : '').'$'.$parameter->getName();
                     },
                     $constructor->getParameters()
@@ -74,7 +74,7 @@ class Constructor extends MethodGenerator
     private static function getConstructor(\ReflectionClass $class): ?MethodReflection
     {
         $constructors = \array_map(
-            function (\ReflectionMethod $method): MethodReflection {
+            static function (\ReflectionMethod $method): MethodReflection {
                 return new MethodReflection(
                     $method->getDeclaringClass()->getName(),
                     $method->getName()
@@ -82,7 +82,7 @@ class Constructor extends MethodGenerator
             },
             \array_filter(
                 $class->getMethods(),
-                function (\ReflectionMethod $method): bool {
+                static function (\ReflectionMethod $method): bool {
                     return $method->isConstructor();
                 }
             )
@@ -107,7 +107,7 @@ class Constructor extends MethodGenerator
             .\implode(
                 ', ',
                 \array_map(
-                    function (\ReflectionProperty $property): string {
+                    static function (\ReflectionProperty $property): string {
                         return '$this->'.$property->getName();
                     },
                     $properties

--- a/src/Proxy/Generator/MethodGenerator/MagicGet.php
+++ b/src/Proxy/Generator/MethodGenerator/MagicGet.php
@@ -62,9 +62,4 @@ PHP;
 
         $this->setBody($body);
     }
-
-    private static function camelize($string)
-    {
-        return;
-    }
 }

--- a/src/Proxy/Generator/MethodGenerator/MagicIsset.php
+++ b/src/Proxy/Generator/MethodGenerator/MagicIsset.php
@@ -14,8 +14,7 @@ class MagicIsset extends MagicMethodGenerator
 {
     public function __construct(
         ReflectionClass $originalClass,
-        ValueHolderProperty $valueHolder,
-        PublicPropertiesMap $publicProperties
+        ValueHolderProperty $valueHolder
     ) {
         parent::__construct($originalClass, '__isset', [new ParameterGenerator('name')]);
 

--- a/src/Proxy/Generator/MethodGenerator/MagicSet.php
+++ b/src/Proxy/Generator/MethodGenerator/MagicSet.php
@@ -67,7 +67,7 @@ PHP;
 
         $body .= "switch(\$name) {\n";
         foreach ($propertyInterceptors as $propertyName => $interceptors) {
-            $interceptors = \array_map(function (string $body): string {
+            $interceptors = \array_map(static function (string $body): string {
                 return \str_replace("\n", "\n        ", $body);
             }, $interceptors);
 

--- a/src/Proxy/Generator/ProxiedMethodsFilter.php
+++ b/src/Proxy/Generator/ProxiedMethodsFilter.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Fazland\DtoManagementBundle\Proxy\Generator;
 
@@ -36,7 +34,7 @@ final class ProxiedMethodsFilter
      */
     public static function getProxiedMethods(ReflectionClass $class, array $excluded = null): array
     {
-        return self::doFilter($class, (null === $excluded) ? self::$defaultExcluded : $excluded);
+        return self::doFilter($class, $excluded ?? self::$defaultExcluded);
     }
 
     /**
@@ -49,7 +47,7 @@ final class ProxiedMethodsFilter
     {
         $ignored = \array_flip(\array_map('strtolower', $excluded));
 
-        return \array_filter($class->getMethods(), function (ReflectionMethod $method) use ($ignored): bool {
+        return \array_filter($class->getMethods(), static function (ReflectionMethod $method) use ($ignored): bool {
             return ! (
                 \array_key_exists(\strtolower($method->getName()), $ignored)
                 || self::methodCannotBeProxied($method)

--- a/src/Proxy/GeneratorStrategy/CacheWriterGeneratorStrategy.php
+++ b/src/Proxy/GeneratorStrategy/CacheWriterGeneratorStrategy.php
@@ -42,7 +42,7 @@ class CacheWriterGeneratorStrategy implements GeneratorStrategyInterface
         $fileName = $this->configuration->getProxiesTargetDir().DIRECTORY_SEPARATOR.\str_replace('\\', '', $className).'.php';
 
         $cacheFactory = new ConfigCacheFactory($this->debug);
-        $cache = $cacheFactory->cache($fileName, function (ConfigCacheInterface $cache) use ($classGenerator) {
+        $cache = $cacheFactory->cache($fileName, static function (ConfigCacheInterface $cache) use ($classGenerator) {
             $superClass = $classGenerator->getExtendedClass();
             $cache->write('<?php '.$classGenerator->generate(), [new ReflectionClassResource(new \ReflectionClass($superClass))]);
         });

--- a/src/Serializer/EventSubscriber/DtoProxySubscriber.php
+++ b/src/Serializer/EventSubscriber/DtoProxySubscriber.php
@@ -3,7 +3,6 @@
 namespace Fazland\DtoManagementBundle\Serializer\EventSubscriber;
 
 use Fazland\DtoManagementBundle\Proxy\ProxyInterface;
-use Kcs\Serializer\EventDispatcher\Events;
 use Kcs\Serializer\EventDispatcher\PreSerializeEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -29,7 +28,8 @@ class DtoProxySubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            Events::PRE_SERIALIZE => ['onPreSerialize', 20],
+            // Cannot use the constant here, as if serializer is non-existent an error would be thrown.
+            'serializer.pre_serialize' => ['onPreSerialize', 20],
         ];
     }
 }


### PR DESCRIPTION
As in the subject, throw an error in `AddInterceptorsPass.php` if the cache directory cannot be created.

Additionally a little code cleanup has been done (mostly closures staticness declaration, remove use of possibly non-existent constant)