### PR TITLE
Add PHP toolbox metadata json

### DIFF
--- a/.ide-toolbox.metadata.json
+++ b/.ide-toolbox.metadata.json
@@ -1,0 +1,29 @@
+{
+    "registrar": [
+        {
+            "signature": [
+                "Fazland\\DtoManagementBundle\\InterfaceResolver\\ResolverInterface::resolve"
+            ],
+            "signatures": [
+                {
+                    "class": "Fazland\\DtoManagementBundle\\InterfaceResolver\\ResolverInterface",
+                    "method": "resolve",
+                    "index": 0,
+                    "type": "type"
+                }
+            ],
+            "provider": "interface",
+            "language": "php"
+        },
+        {
+            "signatures": [
+                {
+                    "class": "Fazland\\DtoManagementBundle\\Annotation\\Transform",
+                    "type": "annotation"
+                }
+            ],
+            "provider": "symfony.services",
+            "language": "php"
+        }
+    ]
+}


### PR DESCRIPTION
Add metadata json to help PHPStorm (with PHP Toolbox installed) to autocomplete

- methods of dto interfaces after `ResolverInterface::resolve` call
- services names in `@Transform` annotation