### PR TITLE
Add var caster to help debug through var dumper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "kcs/serializer": "^2.1|^3.0",
         "phpunit/phpunit": "^7.5",
         "symfony/browser-kit": "^3.4|^4.0",
+        "symfony/debug-bundle": "^3.4|^4.0",
         "symfony/expression-language": "^3.4|^4.0",
         "symfony/security-bundle": "^3.4|^4.0",
         "symfony/var-dumper": "^3.4|^4.0",

--- a/src/DependencyInjection/Compiler/RegisterDtoProxyCasterPass.php
+++ b/src/DependencyInjection/Compiler/RegisterDtoProxyCasterPass.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Fazland\DtoManagementBundle\DependencyInjection\Compiler;
+
+use Fazland\DtoManagementBundle\InterfaceResolver\ResolverInterface;
+use Fazland\DtoManagementBundle\Proxy\ProxyInterface;
+use Fazland\DtoManagementBundle\VarDumper\ProxyCaster;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\VarDumper\Caster\StubCaster;
+
+class RegisterDtoProxyCasterPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        if (! $container->hasDefinition('var_dumper.cloner')) {
+            return;
+        }
+
+        $container->findDefinition('var_dumper.cloner')
+            ->addMethodCall('addCasters', [
+                [
+                    ProxyInterface::class => ProxyCaster::class.'::castDtoProxy',
+                    ResolverInterface::class => StubCaster::class.'::cutInternals',
+                ],
+            ]);
+    }
+}

--- a/src/DtoManagementBundle.php
+++ b/src/DtoManagementBundle.php
@@ -4,6 +4,7 @@ namespace Fazland\DtoManagementBundle;
 
 use Fazland\DtoManagementBundle\DependencyInjection\Compiler\AddInterceptorsPass;
 use Fazland\DtoManagementBundle\DependencyInjection\Compiler\DtoProxySerializerPass;
+use Fazland\DtoManagementBundle\DependencyInjection\Compiler\RegisterDtoProxyCasterPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -17,6 +18,7 @@ final class DtoManagementBundle extends Bundle
         $container
             ->addCompilerPass(new AddInterceptorsPass())
             ->addCompilerPass(new DtoProxySerializerPass())
+            ->addCompilerPass(new RegisterDtoProxyCasterPass())
         ;
     }
 

--- a/src/VarDumper/ProxyCaster.php
+++ b/src/VarDumper/ProxyCaster.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Fazland\DtoManagementBundle\VarDumper;
+
+use Fazland\DtoManagementBundle\Proxy\ProxyInterface;
+use Symfony\Component\VarDumper\Cloner\Stub;
+
+final class ProxyCaster
+{
+    public static function castDtoProxy(ProxyInterface $proxy, array $a, Stub $stub, bool $isNested): array
+    {
+        $original = $a;
+        $prefix = "\0".\get_class($proxy)."\0";
+        $valueHolder = null;
+
+        foreach ($a as $key => $value) {
+            if (0 === \strpos($key, $prefix.'valueHolder')) {
+                $valueHolder = $value;
+                unset($a[$key]);
+            }
+
+            if (0 === \strpos($key, $prefix.'serviceLocator')) {
+                unset($a[$key]);
+            }
+        }
+
+        if (null === $valueHolder) {
+            return $original;
+        }
+
+        $a += (array) $valueHolder;
+        $stub->class = \get_parent_class($proxy).' (proxy)';
+
+        return $a;
+    }
+}

--- a/tests/DependencyInjection/DtoManagementExtensionTest.php
+++ b/tests/DependencyInjection/DtoManagementExtensionTest.php
@@ -77,7 +77,7 @@ class DtoManagementExtensionTest extends TestCase
         ], $definition->getArgument(0));
 
         $versions = $container->getParameter('dto_management.versions');
-        usort($versions, 'version_compare');
-        $this->assertEquals(['1.0', '1.1', '2.0-alpha.1'], $versions);
+        \usort($versions, 'version_compare');
+        self::assertEquals(['1.0', '1.1', '2.0-alpha.1'], $versions);
     }
 }

--- a/tests/Fixtures/Proxy/AppKernel.php
+++ b/tests/Fixtures/Proxy/AppKernel.php
@@ -4,6 +4,7 @@ namespace Fazland\DtoManagementBundle\Tests\Fixtures\Proxy;
 
 use Fazland\DtoManagementBundle\DtoManagementBundle;
 use Fazland\DtoManagementBundle\Tests\Fixtures\TestKernel;
+use Symfony\Bundle\DebugBundle\DebugBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -18,6 +19,7 @@ class AppKernel extends TestKernel
         return [
             new FrameworkBundle(),
             new DtoManagementBundle(),
+            new DebugBundle(),
             new SecurityBundle(),
             new AppBundle(),
         ];

--- a/tests/Fixtures/Proxy/Model/v2017/v20171215/User.php
+++ b/tests/Fixtures/Proxy/Model/v2017/v20171215/User.php
@@ -9,6 +9,11 @@ use Fazland\DtoManagementBundle\Tests\Fixtures\Proxy\Transformer\TestTransform;
 
 class User implements UserInterface
 {
+    public $barPublic = 'pubb';
+
+    /**
+     * @Security("true")
+     */
     public $barBar = 'test';
 
     /**

--- a/tests/ProxyTest.php
+++ b/tests/ProxyTest.php
@@ -5,9 +5,11 @@ namespace Fazland\DtoManagementBundle;
 use Fazland\DtoManagementBundle\InterfaceResolver\ResolverInterface;
 use Fazland\DtoManagementBundle\Tests\Fixtures\Proxy\AppKernel;
 use Fazland\DtoManagementBundle\Tests\Fixtures\Proxy\Model\Interfaces\ExcludedInterface;
+use Fazland\DtoManagementBundle\Tests\Fixtures\Proxy\Model\Interfaces\UserInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
 
 /**
  * @group functional
@@ -124,6 +126,27 @@ class ProxyTest extends WebTestCase
 
         $container = $client->getContainer();
         self::assertFalse($container->get(ResolverInterface::class)->has(ExcludedInterface::class));
+    }
+
+    public function testProxyCasterIsRegistered(): void
+    {
+        $client = self::createClient();
+        $client->getKernel()->boot();
+
+        $container = $client->getContainer();
+        $user = $container->get(ResolverInterface::class)->resolve(UserInterface::class);
+
+        $dumper = new CliDumper();
+        $cloner = $container->get('var_dumper.cloner');
+
+        self::assertStringMatchesFormat(<<<DUMP
+Fazland\\DtoManagementBundle\\Tests\\Fixtures\\Proxy\\Model\\v2017\\v20171215\\User (proxy) {#%d
+  +barPublic: "pubb"
+  +barBar: "test"
+  +foobar: "ciao"
+}
+DUMP
+        , $dumper->dump($cloner->cloneVar($user), true));
     }
 
     /**

--- a/tests/Serializer/EventSubscriber/DtoProxySubscriberTest.php
+++ b/tests/Serializer/EventSubscriber/DtoProxySubscriberTest.php
@@ -4,7 +4,6 @@ namespace Fazland\DtoManagementBundle\Tests\Serializer\EventSubscriber;
 
 use Fazland\DtoManagementBundle\Serializer\EventSubscriber\DtoProxySubscriber;
 use Fazland\DtoManagementBundle\Tests\Fixtures\Model\FooProxy;
-use Kcs\Serializer\EventDispatcher\Events;
 use Kcs\Serializer\EventDispatcher\PreSerializeEvent;
 use Kcs\Serializer\Type\Type;
 use PHPUnit\Framework\TestCase;
@@ -28,7 +27,7 @@ class DtoProxySubscriberTest extends TestCase
     {
         self::assertEquals([
             'serializer.pre_serialize' => ['onPreSerialize', 20],
-            PreSerializeEvent::class => ['onPreSerialize', 20]
+            PreSerializeEvent::class => ['onPreSerialize', 20],
         ], DtoProxySubscriber::getSubscribedEvents());
     }
 

--- a/tests/VarDumper/ProxyCasterTest.php
+++ b/tests/VarDumper/ProxyCasterTest.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace Fazland\DtoManagementBundle\Tests\VarDumper;
+
+use Fazland\DtoManagementBundle\Annotation\Security;
+use Fazland\DtoManagementBundle\Proxy\Factory\AccessInterceptorFactory;
+use Fazland\DtoManagementBundle\Proxy\ProxyInterface;
+use Fazland\DtoManagementBundle\Tests\Fixtures\Proxy\Model\v2017\v20171215\User;
+use Fazland\DtoManagementBundle\VarDumper\ProxyCaster;
+use PHPUnit\Framework\TestCase;
+use ProxyManager\Configuration;
+use ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
+
+class ProxyCasterTest extends TestCase
+{
+    use VarDumperTestTrait;
+
+    protected function getDump($data, $key = null, $filter = 0)
+    {
+        $flags = \getenv('DUMP_LIGHT_ARRAY') ? CliDumper::DUMP_LIGHT_ARRAY : 0;
+        $flags |= \getenv('DUMP_STRING_LENGTH') ? CliDumper::DUMP_STRING_LENGTH : 0;
+        $flags |= \getenv('DUMP_COMMA_SEPARATOR') ? CliDumper::DUMP_COMMA_SEPARATOR : 0;
+
+        $cloner = new VarCloner();
+        $cloner->setMaxItems(-1);
+        $cloner->addCasters([ProxyInterface::class => ProxyCaster::class.'::castDtoProxy']);
+
+        $dumper = new CliDumper(null, null, $flags);
+        $dumper->setColors(false);
+        $data = $cloner->cloneVar($data, $filter)->withRefHandles(false);
+        if (null !== $key && null === $data = $data->seek($key)) {
+            return;
+        }
+
+        return \rtrim($dumper->dump($data, true));
+    }
+
+    public function testShouldCastDtoProxies(): void
+    {
+        $configuration = new Configuration();
+        $configuration->setGeneratorStrategy(new EvaluatingGeneratorStrategy());
+
+        $factory = new AccessInterceptorFactory($configuration);
+        $annotation = new Security();
+        $annotation->expression = 'is_granted(\'ROLE_ADMIN\')';
+
+        $className = $factory->generateProxy(User::class, [
+            'property_interceptors' => [
+                'foobar' => [
+                    [
+                        'annotation' => $annotation,
+                        'parameter' => '',
+                    ],
+                ],
+            ],
+            'services' => [],
+        ]);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $obj = new $className($container->reveal());
+
+        $this->assertDumpEquals(<<<DUMP
+Fazland\\DtoManagementBundle\\Tests\\Fixtures\\Proxy\\Model\\v2017\\v20171215\\User (proxy) {
+  +barPublic: "pubb"
+  +barBar: "test"
+  +foobar: "ciao"
+}
+DUMP
+        , $obj);
+    }
+}


### PR DESCRIPTION
Requires `symfony/debug-bundle` to work correctly as the var cloner service is registered by that bundle.

If debug bundle is not installed, the caster is not registered and `dump` will print the internal values and properties (as before this PR).